### PR TITLE
Adds support for static data

### DIFF
--- a/jasper/src/test/java/it/polimi/deib/sr/rsp/esper/engine/CSPARQLStaticDataExample.java
+++ b/jasper/src/test/java/it/polimi/deib/sr/rsp/esper/engine/CSPARQLStaticDataExample.java
@@ -1,0 +1,71 @@
+package it.polimi.deib.sr.rsp.esper.engine;
+
+import it.polimi.sr.rsp.csparql.engine.CSPARQLEngine;
+import it.polimi.yasper.core.engine.config.EngineConfiguration;
+import it.polimi.yasper.core.querying.ContinuousQuery;
+import it.polimi.yasper.core.querying.ContinuousQueryExecution;
+import it.polimi.yasper.core.sds.SDSConfiguration;
+import it.polimi.yasper.core.stream.data.DataStreamImpl;
+import it.polimi.yasper.core.stream.data.WebDataStream;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.graph.Graph;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Created by Riccardo on 03/08/16.
+ */
+public class CSPARQLStaticDataExample {
+
+    static CSPARQLEngine sr;
+
+    public static void main(String[] args) throws InterruptedException, IOException, ConfigurationException {
+
+        URL resource = CSPARQLStaticDataExample.class.getResource("/csparql.properties");
+        SDSConfiguration config = new SDSConfiguration(resource.getPath());
+        EngineConfiguration ec = EngineConfiguration.loadConfig("/csparql.properties");
+
+
+        sr = new CSPARQLEngine(0, ec);
+
+        GraphStream writer = new GraphStream("Artist", "http://differenthost:12134/stream2", 1);
+
+        DataStreamImpl<Graph> register = sr.register(writer);
+
+        writer.setWritable(register);
+
+        ContinuousQueryExecution cqe = sr.register(getQuery(".rspql"), config);
+
+        ContinuousQuery query = cqe.getContinuousQuery();
+
+        System.out.println(query.toString());
+
+        System.out.println("<<------>>");
+
+//        if (query.isConstructType()) {
+//            cqe.add(ResponseFormatterFactory.getConstructResponseSysOutFormatter("JSON-LD", true));
+//        } else if (query.isSelectType()) {
+//            cqe.add(ResponseFormatterFactory.getSelectResponseSysOutFormatter("TABLE", true)); //or "CSV" or "JSON" or "JSON-LD"
+//        }
+
+        WebDataStream outputStream = cqe.outstream();
+
+        if (outputStream != null)
+            outputStream.addConsumer((o, l) -> System.out.println(o));
+
+        //In real application we do not have to start the stream.
+        (new Thread(writer)).start();
+
+    }
+
+    public static String getQuery(String suffix) throws IOException {
+        URL resource = CSPARQLStaticDataExample.class.getResource("/q52_static" + suffix);
+        System.out.println(resource.getPath());
+        File file = new File(resource.getPath());
+        return FileUtils.readFileToString(file);
+    }
+
+}

--- a/jasper/src/test/resources/q52_static.rspql
+++ b/jasper/src/test/resources/q52_static.rspql
@@ -1,0 +1,18 @@
+PREFIX ars: <http://www.streamreasoning/artist#>
+PREFIX afn: <http://jena.apache.org/ARQ/function#>
+PREFIX wikibase: <http://wikiba.se/ontology#>
+PREFIX : <http://differenthost:12134/>
+
+REGISTER RSTREAM <out> AS
+SELECT  *
+FROM NAMED WINDOW <win2> ON :stream2 [RANGE PT5S STEP PT0.5S]
+FROM <file:///Users/psbonte/Documents/Github/csparql2/jasper/src/test/resources/static.ttl>
+WHERE  {
+    ?a ars:hasName ?name.
+    WINDOW ?w {
+        ?a a ars:Artist ;
+           ars:hasAge ?age .
+    }
+
+     BIND( UUID() as ?uuid )
+}

--- a/jasper/src/test/resources/static.ttl
+++ b/jasper/src/test/resources/static.ttl
@@ -1,0 +1,3 @@
+PREFIX ars: <http://www.streamreasoning/artist#>
+
+<http://differenthost:12134/stream2/artist1> ars:hasName "someName".


### PR DESCRIPTION
Queries with FROM clauses to static data could not be evaluated correctly. These queries were not correctly evaluated because the loaded graphs and named graphs in the query definitions were somehow obstructing the evaluation of the default graph in the data set. Removing the content of the GraphURIs and NamedGraphURIs from the registered queries solved the problem. Note that this is not a problem as they are already loaded in the SDS.